### PR TITLE
fix: Downgraded `xunit.runner.visualstudio`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.core" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.console" Version="2.5.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Because `2.5.0` is not able to execute net3.1 and net5.0 tests